### PR TITLE
로그인 인증 관련 provider 추가, 바텀 네비게이션 경로 go_router 적용

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/core/const/const.dart
+++ b/lib/core/const/const.dart
@@ -1,0 +1,4 @@
+class ApiUrls {
+  static final String baseUrl = 'http://localhost:8000';
+  static final String loginUrl = '$baseUrl/login';
+}

--- a/lib/core/provider/login_provider.dart
+++ b/lib/core/provider/login_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phonics/core/user/data/user_state.dart';
+import 'package:phonics/core/utils/kakao_login.dart'; // KakaoLoginApi
+
+// 로그인 후 반환된 UserResponse 모델을 관리하는 Provider
+// nickname, userId
+final userResponseProvider =
+    StateNotifierProvider<UserResponseNotifier, UserResponse?>((ref) {
+  return UserResponseNotifier();
+});
+
+class UserResponseNotifier extends StateNotifier<UserResponse?> {
+  UserResponseNotifier() : super(null);
+
+  // 카카오 로그인 후 userResponse 상태 업데이트
+  Future<void> signInWithKakao() async {
+    final kakaoLoginApi = KakaoLoginApi();
+    final user = await kakaoLoginApi.signWithKakao();
+    state = user;
+  }
+}

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phonics/screens/home.dart';
+import 'package:phonics/screens/library_tab/home_tab_screen.dart';
+import 'package:phonics/screens/mypage_tab/mypage_screen.dart';
+import 'package:phonics/screens/study_tab/study_tab.dart';
+import 'package:phonics/screens/createbook_tab/createbook_screen.dart';
+import 'package:phonics/widgets/bottom_nav_bar.dart';
+import 'package:phonics/core/router/routes.dart';
+
+final GoRouter appRouter = GoRouter(
+  initialLocation: Routes.home,
+  routes: [
+    ShellRoute(
+      builder: (context, state, child) {
+        // 현재 경로에 맞는 selectedIndex 값 설정
+        int selectedIndex = 0;
+        if (state.uri.toString() == Routes.homeTab) {
+          selectedIndex = 1;
+        } else if (state.uri.toString() == Routes.study) {
+          selectedIndex = 2;
+        } else if (state.uri.toString() == Routes.bookCreation) {
+          selectedIndex = 3;
+        } else if (state.uri.toString() == Routes.myPage) {
+          selectedIndex = 4;
+        }
+
+        // study 화면에서는 하단 네비게이션 바를 숨기도록 처리
+        bool showBottomNavBar = state.uri.toString() != Routes.study;
+
+        return Scaffold(
+          backgroundColor: Colors.transparent, // 전체 배경을 투명하게 설정
+          resizeToAvoidBottomInset: false, // 하단 네비게이션이 콘텐츠를 밀지 않도록 설정
+          body: Stack(
+            children: [
+              Positioned.fill(child: child), // 하위 화면을 Stack 내에 배치
+
+              // 하단 네비게이션 바가 필요할 때만 표시
+              if (showBottomNavBar)
+                Positioned(
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  child: CustomBottomNavBar(
+                    selectedIndex: selectedIndex,
+                    onTabTapped: (index) {
+                      switch (index) {
+                        case 0:
+                          context.go(Routes.home); // 홈으로 이동
+                          break;
+                        case 1:
+                          context.go(Routes.homeTab); // 홈탭으로 이동
+                          break;
+                        case 2:
+                          context.go(Routes.study); // 학습으로 이동
+                          break;
+                        case 3:
+                          context.go(Routes.bookCreation); // 책 생성으로 이동
+                          break;
+                        case 4:
+                          context.go(Routes.myPage); // 마이페이지로 이동
+                          break;
+                        default:
+                          context.go(Routes.home); // 기본적으로 홈
+                      }
+                    },
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+      routes: [
+        GoRoute(
+          path: Routes.home,
+          builder: (context, state) => const MyHomePage(),
+        ),
+        GoRoute(
+          path: Routes.homeTab,
+          builder: (context, state) => const HomeTabScreen(),
+        ),
+        GoRoute(
+          path: Routes.myPage,
+          builder: (context, state) => const MypageScreen(),
+        ),
+        GoRoute(
+          path: Routes.bookCreation,
+          builder: (context, state) => const CreateBookScreen(),
+        ),
+        GoRoute(
+          path: Routes.study,
+          builder: (context, state) => const StudyScreen(),
+        ),
+      ],
+    ),
+  ],
+);

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,19 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:phonics/core/screens/login_screen.dart';
 import 'package:phonics/screens/home.dart';
 import 'package:phonics/screens/library_tab/home_tab_screen.dart';
 import 'package:phonics/screens/mypage_tab/mypage_screen.dart';
+import 'package:phonics/screens/study_tab/phonics_menu.dart';
+import 'package:phonics/screens/study_tab/quiz_menu.dart';
 import 'package:phonics/screens/study_tab/study_tab.dart';
 import 'package:phonics/screens/createbook_tab/createbook_screen.dart';
 import 'package:phonics/widgets/bottom_nav_bar.dart';
 import 'package:phonics/core/router/routes.dart';
+import 'package:phonics/screens/study_tab/quiz_detailmenu.dart';
 
 final GoRouter appRouter = GoRouter(
-  initialLocation: Routes.home,
+  initialLocation: Routes.login,
   routes: [
+    GoRoute(
+      path: Routes.login,
+      builder: (context, state) => const LoginScreen(),
+      routes: [
+        GoRoute(
+          path: Routes.home,
+          builder: (context, state) => const MyHomePage(),
+        ),
+      ],
+    ),
     ShellRoute(
       builder: (context, state, child) {
-        // 현재 경로에 맞는 selectedIndex 값 설정
         int selectedIndex = 0;
         if (state.uri.toString() == Routes.homeTab) {
           selectedIndex = 1;
@@ -25,17 +38,16 @@ final GoRouter appRouter = GoRouter(
           selectedIndex = 4;
         }
 
-        // study 화면에서는 하단 네비게이션 바를 숨기도록 처리
-        bool showBottomNavBar = state.uri.toString() != Routes.study;
+        bool showBottomNavBar = state.uri.toString() == Routes.home ||
+            state.uri.toString() == Routes.homeTab ||
+            state.uri.toString() == Routes.myPage;
 
         return Scaffold(
-          backgroundColor: Colors.transparent, // 전체 배경을 투명하게 설정
-          resizeToAvoidBottomInset: false, // 하단 네비게이션이 콘텐츠를 밀지 않도록 설정
+          backgroundColor: Colors.transparent,
+          resizeToAvoidBottomInset: false,
           body: Stack(
             children: [
-              Positioned.fill(child: child), // 하위 화면을 Stack 내에 배치
-
-              // 하단 네비게이션 바가 필요할 때만 표시
+              Positioned.fill(child: child),
               if (showBottomNavBar)
                 Positioned(
                   bottom: 0,
@@ -46,22 +58,22 @@ final GoRouter appRouter = GoRouter(
                     onTabTapped: (index) {
                       switch (index) {
                         case 0:
-                          context.go(Routes.home); // 홈으로 이동
+                          context.go(Routes.home);
                           break;
                         case 1:
-                          context.go(Routes.homeTab); // 홈탭으로 이동
+                          context.go(Routes.homeTab);
                           break;
                         case 2:
-                          context.go(Routes.study); // 학습으로 이동
+                          context.go(Routes.study);
                           break;
                         case 3:
-                          context.go(Routes.bookCreation); // 책 생성으로 이동
+                          context.go(Routes.bookCreation);
                           break;
                         case 4:
-                          context.go(Routes.myPage); // 마이페이지로 이동
+                          context.go(Routes.myPage);
                           break;
                         default:
-                          context.go(Routes.home); // 기본적으로 홈
+                          context.go(Routes.home);
                       }
                     },
                   ),
@@ -90,6 +102,20 @@ final GoRouter appRouter = GoRouter(
         GoRoute(
           path: Routes.study,
           builder: (context, state) => const StudyScreen(),
+          routes: [
+            GoRoute(
+                path: Routes.quiz,
+                builder: (context, state) => const QuizMenu(),
+                routes: [
+                  GoRoute(
+                      path: Routes.quizDetail,
+                      builder: (context, state) => QuizDetailmenu()),
+                ]),
+            GoRoute(
+              path: Routes.phonics,
+              builder: (context, state) => const PhonicsScreen(),
+            ),
+          ],
         ),
       ],
     ),

--- a/lib/core/router/routes.dart
+++ b/lib/core/router/routes.dart
@@ -1,0 +1,8 @@
+class Routes {
+  static const String home = '/home';
+  static const String homeTab = '/homeTab'; //서재
+  static const String login = '/login';
+  static const String study = '/study';
+  static const String myPage = '/myPage';
+  static const String bookCreation = '/bookCreation';
+}

--- a/lib/core/router/routes.dart
+++ b/lib/core/router/routes.dart
@@ -5,4 +5,9 @@ class Routes {
   static const String study = '/study';
   static const String myPage = '/myPage';
   static const String bookCreation = '/bookCreation';
+
+  static const String quiz = 'quiz';
+  static const String phonics = 'phonics';
+  static const String quizMenu = 'quizMenu';
+  static const String quizDetail = 'quizDetail';
 }

--- a/lib/core/screens/login_screen.dart
+++ b/lib/core/screens/login_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phonics/core/router/routes.dart';
 import 'package:phonics/core/utils/kakaologin.dart';
 import 'package:phonics/screens/home.dart';
 
@@ -57,12 +59,12 @@ class LoginScreen extends StatelessWidget {
                   ),
                 ),
                 TextButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) => const MyHomePage()),
-                    );
+                  onPressed: () async {
+                    final user = await KakaoLoginApi().signWithKakao();
+                    if (user != null) {
+                      // 로그인 성공 후 GoRouter로 MyHomePage로 이동
+                      context.go(Routes.home); // GoRouter 사용
+                    }
                   },
                   child: Container(
                     padding: EdgeInsets.all(16),

--- a/lib/core/screens/login_screen.dart
+++ b/lib/core/screens/login_screen.dart
@@ -1,16 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phonics/core/provider/login_provider.dart';
 import 'package:phonics/core/router/routes.dart';
-import 'package:phonics/core/utils/kakaologin.dart';
-import 'package:phonics/screens/home.dart';
+import 'package:phonics/core/utils/kakao_login.dart';
 
-class LoginScreen extends StatelessWidget {
+class LoginScreen extends ConsumerWidget {
   const LoginScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      backgroundColor: Color(0xffFFFFEB),
+      backgroundColor: const Color(0xffFFFFEB),
       body: SafeArea(
         child: Center(
           child: Padding(
@@ -18,24 +19,24 @@ class LoginScreen extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
+                // 카카오 로그인 버튼
                 TextButton(
                   onPressed: () async {
-                    final user = await KakaoLoginApi().signWithKakao();
-                    if (user != null) {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const MyHomePage(),
-                        ),
-                      );
-                    }
+                    final userResponse = await KakaoLoginApi().signWithKakao();
+                    if (userResponse != null) {
+                      // 로그인 후 상태 업데이트
+                      ref.read(userResponseProvider.notifier).state =
+                          userResponse;
+                      // 로그인 성공 후 홈 화면으로 이동
+                      context.go(Routes.home, extra: userResponse);
+                    } else {}
                   },
                   child: Container(
-                    padding: EdgeInsets.all(16),
+                    padding: const EdgeInsets.all(16),
                     width: double.infinity,
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(10),
-                      color: Color(0xffF5E04D),
+                      color: const Color(0xffF5E04D),
                     ),
                     child: Center(
                       child: Row(
@@ -43,8 +44,8 @@ class LoginScreen extends StatelessWidget {
                         children: [
                           Image.asset('assets/images/core/kakaotalk_logo.png',
                               width: 30),
-                          SizedBox(width: 20),
-                          Text(
+                          const SizedBox(width: 20),
+                          const Text(
                             '카카오톡으로 계속하기',
                             style: TextStyle(
                               fontFamily: 'GyeonggiTitle_Medium',
@@ -58,20 +59,23 @@ class LoginScreen extends StatelessWidget {
                     ),
                   ),
                 ),
+
+                // Google 로그인 버튼 (임시로 카카오 로그인 버튼을 추가)
                 TextButton(
                   onPressed: () async {
-                    final user = await KakaoLoginApi().signWithKakao();
-                    if (user != null) {
-                      // 로그인 성공 후 GoRouter로 MyHomePage로 이동
+                    final userResponse = await KakaoLoginApi().signWithKakao();
+                    if (userResponse != null) {
+                      // 로그인 성공 후 홈 화면으로 이동
+                      print('로그인 성공: ${userResponse.nickname}');
                       context.go(Routes.home); // GoRouter 사용
                     }
                   },
                   child: Container(
-                    padding: EdgeInsets.all(16),
+                    padding: const EdgeInsets.all(16),
                     width: double.infinity,
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(10),
-                      color: Color(0xffFEFEFE),
+                      color: const Color(0xffFEFEFE),
                     ),
                     child: Center(
                       child: Row(
@@ -81,10 +85,10 @@ class LoginScreen extends StatelessWidget {
                             'assets/images/core/google_logo.png',
                             width: 20,
                           ),
-                          SizedBox(
+                          const SizedBox(
                             width: 20,
                           ),
-                          Text(
+                          const Text(
                             'Google로 계속하기',
                             style: TextStyle(
                                 fontFamily: 'GyeonggiTitle_Medium',
@@ -96,7 +100,7 @@ class LoginScreen extends StatelessWidget {
                       ),
                     ),
                   ),
-                )
+                ),
               ],
             ),
           ),

--- a/lib/core/user/data/login_response.dart
+++ b/lib/core/user/data/login_response.dart
@@ -1,0 +1,28 @@
+import 'package:phonics/core/user/data/user_state.dart';
+
+class LoginResponse {
+  final String accessToken;
+  final UserResponse userResponse;
+
+  LoginResponse({
+    required this.accessToken,
+    required this.userResponse,
+  });
+
+  // JSON을 Dart 객체로 변환
+  factory LoginResponse.fromJson(Map<String, dynamic> json) {
+    return LoginResponse(
+      accessToken: json['access_token'],
+      userResponse:
+          UserResponse.fromJson(json['user']), // user key 안에 user 정보가 있다고 가정
+    );
+  }
+
+  // Dart 객체를 JSON으로 변환
+  Map<String, dynamic> toJson() {
+    return {
+      'access_token': accessToken,
+      'user': userResponse.toJson(),
+    };
+  }
+}

--- a/lib/core/user/data/user_state.dart
+++ b/lib/core/user/data/user_state.dart
@@ -1,0 +1,25 @@
+class UserResponse {
+  final String userId;
+  final String nickname;
+
+  UserResponse({
+    required this.userId,
+    required this.nickname,
+  });
+
+  // JSON을 Dart 객체로 변환
+  factory UserResponse.fromJson(Map<String, dynamic> json) {
+    return UserResponse(
+      userId: json['user_id'],
+      nickname: json['nickname'],
+    );
+  }
+
+  // Dart 객체를 JSON으로 변환
+  Map<String, dynamic> toJson() {
+    return {
+      'user_id': userId,
+      'nickname': nickname,
+    };
+  }
+}

--- a/lib/core/utils/api_service.dart
+++ b/lib/core/utils/api_service.dart
@@ -1,13 +1,12 @@
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
-class ApiService {
-  static final String baseUrl = 'http://localhost:8000';
+import 'package:phonics/core/const/const.dart';
 
+class ApiService {
   static Future<void> sendTokenToBackend(
       String accessToken, String provider) async {
-    // 각 provider에 맞는 경로로 요청을 보냄
-    String url = '$baseUrl/login/$provider'; // /login/kakao 또는 /login/google
+    String url = '${ApiUrls.loginUrl}/$provider';
 
     final body = json.encode({
       'access_token': accessToken,
@@ -22,12 +21,11 @@ class ApiService {
         body: body,
       );
 
-      // 응답 상태 코드와 본문을 로그로 출력
       print('Response Status: ${response.statusCode}');
       print('Response Body: ${response.body}');
 
       if (response.statusCode == 200) {
-        print('Token sent to backend successfully');
+        print('백엔드로 access token 전송 성공');
       } else {
         print('Failed to send token to backend: ${response.statusCode}');
       }

--- a/lib/core/utils/kakao_login.dart
+++ b/lib/core/utils/kakao_login.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/services.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+import 'package:phonics/core/user/data/user_state.dart';
 import 'package:phonics/core/utils/api_service.dart';
 
 class KakaoLoginApi {
-  Future<User?> signWithKakao() async {
+  Future<UserResponse?> signWithKakao() async {
     try {
       OAuthToken token;
       if (await isKakaoTalkInstalled()) {
@@ -27,11 +28,20 @@ class KakaoLoginApi {
 
       await ApiService.sendTokenToBackend(token.accessToken, 'kakao');
 
+      // 카카오 로그인 후 사용자 정보 가져오기
       User user = await UserApi.instance.me();
-      return user;
+
+      // User 객체 -> UserResponse로 변환하여 반환
+      UserResponse userResponse = UserResponse(
+        userId: user.id.toString(),
+        nickname: user.properties?['nickname'] ?? 'No Name',
+      );
+
+      print('로그인 성공: ${userResponse.nickname}, UserId: ${userResponse.userId}');
+      return userResponse; // UserResponse 객체 반환
     } catch (error) {
       print('카카오계정으로 로그인 실패: $error');
-      return null;
+      return null; // 로그인 실패 시 null 반환
     }
   }
 }

--- a/lib/data/dailyword_data.dart
+++ b/lib/data/dailyword_data.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 class DailyWord {
   final int id;
   final String word;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_common.dart';
 import 'package:phonics/core/router/app_router.dart';
 import 'package:url_strategy/url_strategy.dart';
@@ -14,7 +15,7 @@ void main() async {
   KakaoSdk.init(
       nativeAppKey: kakaoNativeAppKey, javaScriptAppKey: kakaoJavaScriptKey);
   setPathUrlStrategy();
-  runApp(const MyApp());
+  runApp(const ProviderScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_common.dart';
-import 'package:phonics/core/screens/login_screen.dart';
-import 'screens/study_tab/study_tab.dart';
+import 'package:phonics/core/router/app_router.dart';
 import 'package:url_strategy/url_strategy.dart';
 
 void main() async {
@@ -23,17 +22,13 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       debugShowCheckedModeBanner: false,
       title: 'Flutter Background Image',
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      initialRoute: '/home',
-      routes: {
-        '/home': (context) => const LoginScreen(),
-        '/study': (context) => const StudyScreen(),
-      },
+      routerConfig: appRouter,
     );
   }
 }

--- a/lib/screens/createbook_tab/createbook_screen.dart
+++ b/lib/screens/createbook_tab/createbook_screen.dart
@@ -1,3 +1,6 @@
+import 'package:go_router/go_router.dart';
+import 'package:phonics/core/router/routes.dart';
+
 import 'character_selection_screen.dart';
 import 'gender_age_screen.dart';
 import 'lesson_selection_screen.dart';
@@ -199,7 +202,7 @@ class _CreateBookScreenState extends State<CreateBookScreen> {
                 child: IconButton(
                   icon: const Icon(Icons.arrow_back_rounded, size: 20),
                   onPressed: () {
-                    Navigator.pushNamed(context, '/home');
+                    context.go(Routes.home);
                   },
                 ),
               ),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,23 +1,18 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:phonics/core/router/routes.dart';
-import 'package:phonics/screens/library_tab/home_tab_screen.dart';
-import 'package:phonics/screens/study_tab/study_tab.dart';
-import '../widgets/bottom_nav_bar.dart';
-import '../screens/mypage_tab/mypage_screen.dart';
-import 'createbook_tab/createbook_screen.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:phonics/core/provider/login_provider.dart';
 import '../data/dailyword_data.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 
-class MyHomePage extends StatefulWidget {
+class MyHomePage extends ConsumerStatefulWidget {
   const MyHomePage({super.key});
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  ConsumerState<MyHomePage> createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
-  final int _selectedIndex = 0;
+class _MyHomePageState extends ConsumerState<MyHomePage>
+    with TickerProviderStateMixin {
   int _consecutiveDays = 0;
   bool _isChecked = false;
   bool _showBubble = false;
@@ -90,6 +85,8 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
+    final userResponse = ref.watch(userResponseProvider);
+
     return Scaffold(
       backgroundColor: const Color(0xFFFFF8E1),
       body: SafeArea(
@@ -102,8 +99,8 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     // 앱 로고/이름
-                    const Text(
-                      'APP LOGO | NAME',
+                    Text(
+                      'APP LOGO | ${userResponse?.nickname ?? 'Guest'} 님',
                       style: TextStyle(
                         fontSize: 24,
                         fontWeight: FontWeight.bold,

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phonics/core/router/routes.dart';
 import 'package:phonics/screens/library_tab/home_tab_screen.dart';
 import 'package:phonics/screens/study_tab/study_tab.dart';
 import '../widgets/bottom_nav_bar.dart';
@@ -15,7 +17,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
-  int _selectedIndex = 0;
+  final int _selectedIndex = 0;
   int _consecutiveDays = 0;
   bool _isChecked = false;
   bool _showBubble = false;
@@ -77,43 +79,6 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
         }
       });
     });
-  }
-
-  void _onTabTapped(int index) {
-    if (_selectedIndex == index) return;
-
-    setState(() {
-      _selectedIndex = index;
-    });
-
-    Widget page;
-    switch (index) {
-      case 0:
-        page = const MyHomePage();
-        break;
-      case 1:
-        page = const HomeTabScreen();
-        break;
-      case 2:
-        page = const StudyScreen();
-        break;
-      case 3:
-        page = const CreateBookScreen();
-        break;
-      case 4:
-        page = const MypageScreen();
-        break;
-      default:
-        page = const MyHomePage();
-    }
-
-    Navigator.of(context).pushReplacement(
-      PageRouteBuilder(
-        pageBuilder: (_, __, ___) => page,
-        transitionDuration: Duration.zero,
-        reverseTransitionDuration: Duration.zero,
-      ),
-    );
   }
 
   @override
@@ -448,10 +413,6 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
             ),
           ],
         ),
-      ),
-      bottomNavigationBar: CustomBottomNavBar(
-        selectedIndex: _selectedIndex,
-        onTabTapped: _onTabTapped,
       ),
     );
   }

--- a/lib/screens/library_tab/home_tab_screen.dart
+++ b/lib/screens/library_tab/home_tab_screen.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:phonics/core/router/routes.dart';
 import 'recent_section.dart';
 import 'ranking_section.dart';
 import 'favorite_section.dart';
-import 'package:phonics/widgets/bottom_nav_bar.dart';
 
 class HomeTabScreen extends StatefulWidget {
   const HomeTabScreen({super.key});
@@ -15,10 +12,6 @@ class HomeTabScreen extends StatefulWidget {
 
 class _HomeTabScreenState extends State<HomeTabScreen>
     with SingleTickerProviderStateMixin {
-  final int _selectedIndex = 1;
-
-  //int _selectedIndex = 0;
-
   late TabController _tabController;
 
   @override

--- a/lib/screens/library_tab/home_tab_screen.dart
+++ b/lib/screens/library_tab/home_tab_screen.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phonics/core/router/routes.dart';
 import 'recent_section.dart';
 import 'ranking_section.dart';
 import 'favorite_section.dart';
 import 'package:phonics/widgets/bottom_nav_bar.dart';
-import '../home.dart';
-import '../study_tab/study_tab.dart';
-import '../mypage_tab/mypage_screen.dart';
 
 class HomeTabScreen extends StatefulWidget {
   const HomeTabScreen({super.key});
@@ -16,7 +15,7 @@ class HomeTabScreen extends StatefulWidget {
 
 class _HomeTabScreenState extends State<HomeTabScreen>
     with SingleTickerProviderStateMixin {
-  int _selectedIndex = 1;
+  final int _selectedIndex = 1;
 
   //int _selectedIndex = 0;
 
@@ -32,44 +31,6 @@ class _HomeTabScreenState extends State<HomeTabScreen>
   void dispose() {
     _tabController.dispose();
     super.dispose();
-  }
-
-  @override
-  void _onTabTapped(int index) {
-    if (_selectedIndex == index) return;
-
-    setState(() {
-      _selectedIndex = index;
-    });
-
-    Widget page;
-    switch (index) {
-      case 0:
-        page = const MyHomePage();
-        break;
-      case 1:
-        page = const HomeTabScreen();
-        break;
-      case 2:
-        page = const StudyScreen();
-        break;
-      // case 3:
-      //   page = const CreateBookPage();
-      //   break;
-      case 4:
-        page = const MypageScreen();
-        break;
-      default:
-        page = const MyHomePage();
-    }
-
-    Navigator.of(context).pushReplacement(
-      PageRouteBuilder(
-        pageBuilder: (_, __, ___) => page,
-        transitionDuration: Duration.zero,
-        reverseTransitionDuration: Duration.zero,
-      ),
-    );
   }
 
   @override
@@ -231,15 +192,6 @@ class _HomeTabScreenState extends State<HomeTabScreen>
                 ),
               ),
             ],
-          ),
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: CustomBottomNavBar(
-              selectedIndex: _selectedIndex,
-              onTabTapped: _onTabTapped,
-            ),
           ),
         ],
       ),

--- a/lib/screens/mypage_tab/mypage_screen.dart
+++ b/lib/screens/mypage_tab/mypage_screen.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phonics/core/router/routes.dart';
 import 'package:phonics/screens/mypage_tab/mypage_to_deleteaccount.dart';
 import 'package:phonics/screens/mypage_tab/mypage_to_notice.dart';
 import 'package:phonics/screens/mypage_tab/mypage_to_voicesetting.dart';
-import '../library_tab/home_tab_screen.dart';
-import '../home.dart';
-import '../study_tab/study_tab.dart';
 import '../../widgets/bottom_nav_bar.dart';
 import 'package:phonics/screens/mypage_tab/mypage_to_favoritebooks.dart';
 
@@ -17,7 +16,7 @@ class MypageScreen extends StatefulWidget {
 
 class _MypageScreenState extends State<MypageScreen>
     with SingleTickerProviderStateMixin {
-  int _selectedIndex = 4;
+  final int _selectedIndex = 4;
 
   //toggle
   bool isTopSelected = true;
@@ -44,43 +43,6 @@ class _MypageScreenState extends State<MypageScreen>
     _toggleController.dispose();
     _inputController.dispose();
     super.dispose();
-  }
-
-  void _onTabTapped(int index) {
-    if (_selectedIndex == index) return;
-
-    setState(() {
-      _selectedIndex = index;
-    });
-
-    Widget page;
-    switch (index) {
-      case 0:
-        page = const MyHomePage();
-        break;
-      case 1:
-        page = const HomeTabScreen();
-        break;
-      case 2:
-        page = const StudyScreen();
-        break;
-      // case 3:
-      //   page = 책만들기();
-      // break;
-      case 4:
-        page = const MypageScreen();
-        break;
-      default:
-        page = const MyHomePage();
-    }
-
-    Navigator.of(context).pushReplacement(
-      PageRouteBuilder(
-        pageBuilder: (_, __, ___) => page,
-        transitionDuration: Duration.zero,
-        reverseTransitionDuration: Duration.zero,
-      ),
-    );
   }
 
   @override
@@ -142,10 +104,6 @@ class _MypageScreenState extends State<MypageScreen>
             child: buildToggleButton(screenWidth),
           ),
         ],
-      ),
-      bottomNavigationBar: CustomBottomNavBar(
-        selectedIndex: _selectedIndex,
-        onTabTapped: _onTabTapped,
       ),
     );
   }

--- a/lib/screens/mypage_tab/mypage_screen.dart
+++ b/lib/screens/mypage_tab/mypage_screen.dart
@@ -1,23 +1,20 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:phonics/core/router/routes.dart';
+import 'package:phonics/core/provider/login_provider.dart';
 import 'package:phonics/screens/mypage_tab/mypage_to_deleteaccount.dart';
 import 'package:phonics/screens/mypage_tab/mypage_to_notice.dart';
 import 'package:phonics/screens/mypage_tab/mypage_to_voicesetting.dart';
-import '../../widgets/bottom_nav_bar.dart';
 import 'package:phonics/screens/mypage_tab/mypage_to_favoritebooks.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class MypageScreen extends StatefulWidget {
+class MypageScreen extends ConsumerStatefulWidget {
   const MypageScreen({super.key});
 
   @override
-  State<MypageScreen> createState() => _MypageScreenState();
+  ConsumerState<MypageScreen> createState() => _MypageScreenState();
 }
 
-class _MypageScreenState extends State<MypageScreen>
-    with SingleTickerProviderStateMixin {
-  final int _selectedIndex = 4;
-
+class _MypageScreenState extends ConsumerState<MypageScreen>
+    with TickerProviderStateMixin {
   //toggle
   bool isTopSelected = true;
   late AnimationController _toggleController;
@@ -25,7 +22,6 @@ class _MypageScreenState extends State<MypageScreen>
 
   //'확인' 버튼
   final TextEditingController _inputController = TextEditingController();
-  final bool _isInputValid = false;
 
   @override
   void initState() {
@@ -209,6 +205,7 @@ class _MypageScreenState extends State<MypageScreen>
   }
 
   Widget buildProfileContainer() {
+    final userResponse = ref.watch(userResponseProvider);
     double screenWidth = MediaQuery.of(context).size.width;
     double containerHeight = screenWidth * 0.69444444444;
     double profileDiameter = screenWidth * 0.25;
@@ -232,12 +229,12 @@ class _MypageScreenState extends State<MypageScreen>
                   height: profileDiameter,
                 ),
                 const SizedBox(width: 16),
-                const Column(
+                Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'Real Name',
+                      '${userResponse?.nickname ?? 'Real Name'} 님',
                       style: TextStyle(
                         fontFamily: 'GyeonggiTitleVBold',
                         fontSize: 20,

--- a/lib/screens/mypage_tab/mypage_to_voicesetting.dart
+++ b/lib/screens/mypage_tab/mypage_to_voicesetting.dart
@@ -3,7 +3,6 @@ import '../../widgets/mypage_audio_card.dart'; // AudioCard(title: , date: ) 구
 import 'package:flutter_sound/flutter_sound.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:path_provider/path_provider.dart';
-import 'dart:io';
 import 'package:audio_session/audio_session.dart';
 
 class MypageToVoicesetting extends StatefulWidget {

--- a/lib/screens/study_tab/phonics_menu.dart
+++ b/lib/screens/study_tab/phonics_menu.dart
@@ -1,5 +1,5 @@
-
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'lesson_screen.dart'; // LessonScreen import
 
 class PhonicsScreen extends StatelessWidget {
@@ -9,88 +9,80 @@ class PhonicsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     double screenWidth = MediaQuery.of(context).size.width;
 
-    return Scaffold(
-      extendBodyBehindAppBar: true,
-      body: Stack(
-        children: [
-          ListView(
-            children: [
-              Container(
-                decoration: const BoxDecoration(
-                  image: DecorationImage(
-                    image: AssetImage('assets/images/phonics_background2.png'),
-                    repeat: ImageRepeat.repeatY,
-                    fit: BoxFit.fitWidth,
-                  ),
-                ),
-                child: Column(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.all(20.0),
-                      child: Column(
-                        children: List.generate(
-                          25,
-                          (index) => GestureDetector(
-                            onTap: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (context) =>
-                                      LessonScreen(lessonNumber: index + 1),
-                                ),
-                              );
-                            },
-                            child: Container(
-                              margin: const EdgeInsets.symmetric(vertical: 10),
-                              padding: const EdgeInsets.all(20),
-                              decoration: BoxDecoration(
-                                color: Colors.white.withOpacity(0.8),
-                                borderRadius: BorderRadius.circular(15),
-                              ),
-                              child: Text(
-                                "Phonics Lesson ${index + 1}",
-                                style: const TextStyle(
-                                    fontSize: 20, fontWeight: FontWeight.bold),
-                              ),
-                            ),
+    return Container(
+      decoration: BoxDecoration(
+        image: DecorationImage(
+          fit: BoxFit.cover,
+          image: const AssetImage('assets/images/phonics_background2.png'),
+        ),
+      ),
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: Stack(
+          children: [
+            ListView(
+              children: [
+                Column(
+                  children: List.generate(
+                    25,
+                    (index) => GestureDetector(
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) =>
+                                LessonScreen(lessonNumber: index + 1),
                           ),
+                        );
+                      },
+                      child: Container(
+                        margin: const EdgeInsets.symmetric(vertical: 10),
+                        padding: const EdgeInsets.all(20),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withOpacity(0.8),
+                          borderRadius: BorderRadius.circular(15),
+                        ),
+                        child: Text(
+                          "Phonics Lesson ${index + 1}",
+                          style: const TextStyle(
+                              fontSize: 20, fontWeight: FontWeight.bold),
                         ),
                       ),
                     ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          Positioned(
-            left: screenWidth * 0.055,
-            top: screenWidth * 0.055,
-            child: SafeArea(
-              child: Container(
-                width: screenWidth * 0.1,
-                height: screenWidth * 0.1,
-                decoration: BoxDecoration(
-                    color: Colors.white,
-                    shape: BoxShape.circle,
-                    boxShadow: [
-                      BoxShadow(
-                        offset: const Offset(0, 2),
-                        color: Colors.black.withOpacity(0.3),
-                      )
-                    ]),
-                child: IconButton(
-                  icon: const Icon(
-                    Icons.arrow_back_rounded,
-                    size: 25,
                   ),
-                  onPressed: () {
-                    Navigator.pushNamed(context, '/home');
-                  },
+                ),
+              ],
+            ),
+            Positioned(
+              left: screenWidth * 0.055,
+              top: screenWidth * 0.055,
+              child: SafeArea(
+                child: Container(
+                  width: screenWidth * 0.1,
+                  height: screenWidth * 0.1,
+                  decoration: BoxDecoration(
+                      color: Colors.white,
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          offset: const Offset(0, 2),
+                          color: Colors.black.withOpacity(0.3),
+                        )
+                      ]),
+                  child: IconButton(
+                    icon: const Icon(
+                      Icons.arrow_back_rounded,
+                      size: 25,
+                    ),
+                    onPressed: () {
+                      context.pop();
+                    },
+                  ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/study_tab/quiz_menu.dart
+++ b/lib/screens/study_tab/quiz_menu.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import '../../widgets/quiz_menu_container.dart'; // LessonScreen import
 
 class QuizMenu extends StatelessWidget {
@@ -12,7 +13,7 @@ class QuizMenu extends StatelessWidget {
         title: const Text("Quiz Menu"),
         leading: IconButton(
           onPressed: () {
-            Navigator.pop(context); //뒤로 가기
+            context.pop();
           },
           color: const Color(0xff7C7B73),
           icon: const Icon(Icons.arrow_back),
@@ -26,49 +27,7 @@ class QuizMenu extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  const Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Text(
-                            'Hi, ',
-                            style: TextStyle(
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                              color: Color(0xff363535),
-                            ),
-                          ),
-                          Text(
-                            'nickname',
-                            style: TextStyle(
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                              color: Color(0xff363535),
-                            ),
-                          )
-                        ],
-                      ),
-                      Text(
-                        "Let's make this day productive",
-                        style: TextStyle(
-                          fontSize: 10,
-                          fontWeight: FontWeight.bold,
-                          color: Color(0xffA0A09A),
-                        ),
-                      ),
-                    ],
-                  ),
-                  Image.asset(
-                    'assets/images/dinosaur.png',
-                    width: 75,
-                    height: 75,
-                  )
-                ],
-              ),
+              const NickNameSection(),
               const SizedBox(
                 height: 30,
               ),
@@ -83,49 +42,67 @@ class QuizMenu extends StatelessWidget {
               const SizedBox(
                 height: 15,
               ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  QuizMenuContainer(
-                    onTap: () {},
-                  ),
-                  QuizMenuContainer(
-                    onTap: () {},
-                  ),
-                ],
+              QuizMenuContainer(
+                onTap: () {},
               ),
               const SizedBox(
                 height: 20,
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  QuizMenuContainer(
-                    onTap: () {},
-                  ),
-                  QuizMenuContainer(
-                    onTap: () {},
-                  ),
-                ],
-              ),
-              const SizedBox(
-                height: 20,
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  QuizMenuContainer(
-                    onTap: () {},
-                  ),
-                  QuizMenuContainer(
-                    onTap: () {},
-                  ),
-                ],
               ),
             ],
           ),
         ),
       ),
+    );
+  }
+}
+
+class NickNameSection extends StatelessWidget {
+  const NickNameSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        const Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  'Hi, ',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xff363535),
+                  ),
+                ),
+                Text(
+                  'nickname',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xff363535),
+                  ),
+                )
+              ],
+            ),
+            Text(
+              "Let's make this day productive",
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+                color: Color(0xffA0A09A),
+              ),
+            ),
+          ],
+        ),
+        Image.asset(
+          'assets/images/dinosaur.png',
+          width: 75,
+          height: 75,
+        )
+      ],
     );
   }
 }

--- a/lib/screens/study_tab/study_tab.dart
+++ b/lib/screens/study_tab/study_tab.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phonics/core/router/routes.dart';
 import '../../widgets/phonics_button.dart';
 import '../../widgets/quiz_button.dart';
 
@@ -55,11 +57,11 @@ class _StudyScreenState extends State<StudyScreen> {
                     ]),
                 child: IconButton(
                   icon: const Icon(
-                    Icons.arrow_back_rounded,
+                    Icons.home,
                     size: 25,
                   ),
                   onPressed: () {
-                    Navigator.pushNamed(context, '/home');
+                    context.go(Routes.home);
                   },
                 ),
               ),

--- a/lib/widgets/bottom_nav_bar.dart
+++ b/lib/widgets/bottom_nav_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class CustomBottomNavBar extends StatelessWidget {
   final int selectedIndex;
@@ -15,8 +16,6 @@ class CustomBottomNavBar extends StatelessWidget {
     double screenWidth = MediaQuery.of(context).size.width;
     double screenHeight = MediaQuery.of(context).size.height;
 
-    double iconSize = 70;
-
     return SafeArea(
       child: Stack(
         clipBehavior: Clip.none,
@@ -25,7 +24,6 @@ class CustomBottomNavBar extends StatelessWidget {
           Container(
             margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 15),
             height: screenHeight * 0.072,
-            // width: screenWidth, // 이 줄은 빼세요!
             decoration: BoxDecoration(
               color: const Color(0xffFFFCC3),
               boxShadow: [
@@ -41,7 +39,6 @@ class CustomBottomNavBar extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                // 탭 1
                 Expanded(
                   child: _buildTabItem(
                     index: 1,
@@ -53,7 +50,6 @@ class CustomBottomNavBar extends StatelessWidget {
                     screenWidth: screenWidth,
                   ),
                 ),
-                // 탭 2
                 Expanded(
                   child: _buildTabItem(
                     index: 2,
@@ -64,9 +60,7 @@ class CustomBottomNavBar extends StatelessWidget {
                     screenWidth: screenWidth,
                   ),
                 ),
-                // 중앙 홈 버튼 공간용 (아무것도 없음)
-                const SizedBox(width: 60), // 홈버튼이 겹치지 않게 적당히 공간 확보
-                // 탭 3
+                const SizedBox(width: 60), // 중앙 홈 버튼 공간
                 Expanded(
                   child: _buildTabItem(
                     index: 3,
@@ -78,7 +72,6 @@ class CustomBottomNavBar extends StatelessWidget {
                     screenWidth: screenWidth,
                   ),
                 ),
-                // 탭 4
                 Expanded(
                   child: _buildTabItem(
                     index: 4,
@@ -116,7 +109,7 @@ class CustomBottomNavBar extends StatelessWidget {
             child: GestureDetector(
               onTap: () {
                 if (selectedIndex != 0) {
-                  onTabTapped(0);
+                  onTabTapped(0); // 중앙 홈 버튼 클릭 시 홈으로 이동
                 }
               },
               child: Container(
@@ -160,7 +153,7 @@ class CustomBottomNavBar extends StatelessWidget {
     return GestureDetector(
       onTap: () {
         if (selectedIndex != index) {
-          onTabTapped(index);
+          onTabTapped(index); // 탭을 클릭할 때 onTabTapped 호출
         }
       },
       child: Column(

--- a/lib/widgets/phonics_button.dart
+++ b/lib/widgets/phonics_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:phonics/screens/study_tab/phonics_menu.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phonics/core/router/routes.dart';
 
 class PhonicsButton extends StatelessWidget {
   const PhonicsButton({super.key});
@@ -10,10 +11,7 @@ class PhonicsButton extends StatelessWidget {
       imageAsset: 'assets/images/abc_button_logo.png',
       color: const Color(0xffcebc62),
       onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(builder: (context) => const PhonicsScreen()),
-        );
+        context.go('${Routes.study}/${Routes.phonics}');
       },
     );
   }

--- a/lib/widgets/quiz_button.dart
+++ b/lib/widgets/quiz_button.dart
@@ -1,23 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:phonics/screens/study_tab/quiz_menu.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phonics/core/router/routes.dart';
 
 class QuizButton extends StatelessWidget {
   const QuizButton({super.key});
 
   @override
   Widget build(BuildContext context) {
-    double screenWidth = MediaQuery.of(context).size.width;
-    double screenHeight = MediaQuery.of(context).size.height;
     return _buildButton(
       imageAsset: 'assets/images/start_quiz_button_logo.png',
       color: const Color(0xffb7c0f9),
       onTap: () {
-        Navigator.push(
-          context,
-          // MaterialPageRoute(builder: (context) => const QuizScreen()),
-
-          MaterialPageRoute(builder: (context) => const QuizMenu()),
-        );
+        context.go('${Routes.study}/${Routes.quiz}');
       },
     );
   }

--- a/lib/widgets/quiz_menu_container.dart
+++ b/lib/widgets/quiz_menu_container.dart
@@ -21,8 +21,8 @@ class _QuizMenuContainer extends State<QuizMenuContainer> {
         );
       },
       child: Container(
-        width: 175,
-        height: 165,
+        padding: const EdgeInsets.all(16),
+        width: double.infinity,
         decoration: BoxDecoration(
           color: Colors.white,
           borderRadius: BorderRadius.circular(17),
@@ -35,47 +35,46 @@ class _QuizMenuContainer extends State<QuizMenuContainer> {
             )
           ],
         ),
-        child: Stack(
-          alignment: AlignmentDirectional.center,
-          clipBehavior: Clip.none,
+        child: Row(
           children: [
-            Positioned(
-              top: -15,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Image.asset(
-                    'assets/images/abc_letter_logo.png',
-                    width: 150,
-                  ),
-                  const SizedBox(
-                    height: 10,
-                  ),
-                  const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 10),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Level 1 ABC',
-                          style: TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        Text(
-                          '6 Questions',
-                          style: TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold,
-                              color: Color(0xffA5A5A5)),
-                        ),
-                      ],
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Image.asset(
+                      'assets/images/abc_letter_logo.png',
+                      width: 150,
                     ),
-                  ),
-                ],
-              ),
-            )
+                    const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 10),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Level 1 ABC',
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          Text(
+                            '6 Questions',
+                            style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xffA5A5A5)),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const Spacer(),
+            Icon(Icons.arrow_forward_ios_rounded,
+                size: 26, color: Color(0xffA5A5A5)),
           ],
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,6 +174,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_sound:
     dependency: "direct main"
     description:
@@ -276,10 +284,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   http_parser:
     dependency: transitive
     description:
@@ -576,6 +584,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.9.1"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   rxdart:
     dependency: transitive
     description:
@@ -661,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -216,6 +216,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "8b1f37dfaf6e958c6b872322db06f946509433bec3de753c3491a42ae9ec2b48"
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.1.0"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -408,6 +416,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,11 +15,12 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_dotenv: ^5.2.1
+  flutter_riverpod: ^2.6.1
   flutter_sound: ^9.28.0
   flutter_tts: ^4.2.3
   go_router: ^16.1.0
   google_sign_in: ^7.1.1
-  http: ^1.4.0
+  http: ^1.5.0
   kakao_flutter_sdk: ^1.9.7+3
   kakao_flutter_sdk_user: ^1.9.7+3
   path_provider: ^2.1.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter_dotenv: ^5.2.1
   flutter_sound: ^9.28.0
   flutter_tts: ^4.2.3
+  go_router: ^16.1.0
   google_sign_in: ^7.1.1
   http: ^1.4.0
   kakao_flutter_sdk: ^1.9.7+3


### PR DESCRIPTION
- API URL 관리를 중앙에서 처리하기 위해 ApiUrls 클래스를 추가함
- Riverpod을 사용하여 사용자 로그인 상태를 관리하는 login_provider.dart 생성
- app_router.dart를 수정하여 로그인 경로를 추가하고 초기 경로를 조정함
- routes.dart에 퀴즈 및 파닉스 화면의 경로를 정의함
- login_screen.dart를 개발하여 사용자 로그인 처리 및 상태 업데이트를 구현함
- 사용자 데이터 관리를 위해 LoginResponse 및 UserResponse 모델을 도입함
- api_service.dart를 개선하여 액세스 토큰을 백엔드로 전송하도록 구현함
- 카카오 로그인 처리를 위한 KakaoLoginApi를 구현함
- 홈, 마이페이지, 파닉스, 퀴즈 등 여러 화면을 리팩토링하여 Riverpod 기반 사용자 상태 관리 방식으로 변경함
- pubspec.yaml과 pubspec.lock을 수정하여 Riverpod 의존성을 추가함